### PR TITLE
Cli config

### DIFF
--- a/.changeset/grumpy-taxis-provide.md
+++ b/.changeset/grumpy-taxis-provide.md
@@ -1,0 +1,5 @@
+---
+"@alduino/pkg-lib": minor
+---
+
+Set configuration from the CLI

--- a/README.md
+++ b/README.md
@@ -33,7 +33,22 @@ Inspired by [tsdx](https://tsdx.io/), [aqu](https://github.com/ArtiomTr/aqu).
 
 3. Run `pkg-lib build`
 
-## Usage
+## CLI
+
+For now there is only one command:
+
+```shell
+pkg-lib build
+```
+
+- `-c, --config`: The path to the configuration file. Defaults to `.pkglibrc`.
+- `--no-dev`: Disables `__DEV__` replacement
+- `--no-invariant`: Disables `invariant` optimisation
+- `--no-warning`: Disables `warning` optimisation
+
+Other than this, you can use all the configuration values in the CLI too. This will override all other configuration. See `pkg-lib build --help` for more info.
+
+## Configuration
 
 pkg-lib reads its config from a `.pkglibrc` JSON file. Here’s the big list of every configuration option.
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,16 +1,30 @@
 import sade from "sade";
-import {name as packageName, version as packageVersion} from "../package.json";
+import {version as packageVersion} from "../package.json";
 import build from "./commands/build";
 
 export default function createCli(args: string[]) {
-    const prog = sade(packageName);
+    const prog = sade("pkg-lib");
 
     prog.version(packageVersion)
         .option("--verbose, -V", "Enables verbose logging", false);
 
     prog.command("build")
         .describe("Bundles the library a single time.")
-        .option("--config, -c <path>", "Path to the configuration file", ".pkglibrc")
+        .option("-c, --config <path>", "Path to the configuration file", ".pkglibrc")
+        .option("-e, --entrypoint <path>", "File to enter from")
+        .option("-T, --typings <path>", "Output for Typescript typings")
+        .option("-O, --cjsOut <path>", "Output for CommonJS entrypoint")
+        .option("-C, --cjsDevOut <path>", "Output for CommonJS development build")
+        .option("-P, --cjsProdOut <path>", "Output for CommonJS production build")
+        .option("-E, --esmOut <path>", "Output for ESModule build")
+        .option("-p, --platform <name>", "Target platform")
+        .option("-t, --target <name>", "Javascript syntax and standard library available")
+        .option("-D, --no-dev", "Disable __DEV__")
+        .option("-I, --no-invariant", "Disable invariant function optimisation")
+        .option("-W, --no-warning", "Disable warning function optimisation")
+        .option("-i, --invariant <name>", "Change invariant function name")
+        .option("-w, --warning <name>", "Change warning function name")
+        .option("-d, --docsDir <path>", "Output directory for documentation files")
         .action(build);
 
     prog.parse(args);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,6 +10,7 @@ export default function createCli(args: string[]) {
 
     prog.command("build")
         .describe("Bundles the library a single time.")
+        .option("--config, -c <path>", "Path to the configuration file", ".pkglibrc")
         .action(build);
 
     prog.parse(args);

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -5,10 +5,18 @@ import run from "../utils/tasks";
 import prepare from "../tasks/prepare";
 import bundle from "../tasks/bundle";
 import logger from "consola";
+import Config from "../Config";
 
-export interface BuildOpts extends StandardOpts {
+interface BuildOptsChanges extends StandardOpts {
     config?: string;
+    noDev?: boolean;
+    noInvariant?: boolean;
+    noWarning?: boolean;
+    invariant?: string;
+    warning?: string;
 }
+
+export type BuildOpts = Partial<Omit<Config, keyof BuildOptsChanges>> & BuildOptsChanges;
 
 export default async function build(opts: BuildOpts) {
     const context: TaskContext = {

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -7,6 +7,7 @@ import bundle from "../tasks/bundle";
 import logger from "consola";
 
 export interface BuildOpts extends StandardOpts {
+    config?: string;
 }
 
 export default async function build(opts: BuildOpts) {

--- a/src/tasks/prepare.ts
+++ b/src/tasks/prepare.ts
@@ -3,6 +3,6 @@ import {createStaticTask} from "./utils";
 
 export default createStaticTask("Prepare", async (_, then) => {
     await then("Read configuration", async ctx => {
-        ctx.config = await readConfig();
+        ctx.config = await readConfig(ctx.opts);
     });
 });

--- a/src/utils/readConfig.ts
+++ b/src/utils/readConfig.ts
@@ -5,6 +5,7 @@ import resolveUserFile from "./resolveUserFile";
 import detectEntrypoint from "./detectEntrypoint";
 import readPackageInformation from "./readPackageInformation";
 import {BuildOpts} from "../commands/build";
+import invariant from "tiny-invariant";
 
 interface FileConfigChanges {
     invariant?: string[] | string | false;
@@ -14,14 +15,27 @@ interface FileConfigChanges {
 
 type FileConfig = Partial<Omit<Config, keyof FileConfigChanges>> & FileConfigChanges;
 
-interface ConfigReader {
+interface ConfigReaderBase<Type extends string, Source> {
+    type: Type;
+    order?: number;
+    read(source: Source): FileConfig;
+}
+
+interface FileConfigReader extends ConfigReaderBase<"file", string> {
     path: string;
 
     read(source: string): FileConfig;
 }
 
+interface CliConfigReader extends ConfigReaderBase<"cli", BuildOpts> {
+    read(source: BuildOpts): FileConfig;
+}
+
+type ConfigReader = FileConfigReader | CliConfigReader;
+
 const staticReaders: ConfigReader[] = [
     {
+        type: "file",
         path: "package.json",
         read(source) {
             const {source: entrypoint, main, module, typings, docs} = JSON.parse(source);
@@ -34,8 +48,27 @@ const staticReaders: ConfigReader[] = [
                 docsDir: docs
             };
         }
+    },
+    {
+        type: "cli",
+        order: Infinity,
+        read(source) {
+            invariant(!(source.noInvariant && source.invariant), "--invariant cannot be specified while --no-invariant is set");
+            invariant(!(source.noWarning && source.warning), "--warning cannot be specified while --no-warning is set");
+
+            return {
+                ...source,
+                dev: !source.noDev,
+                invariant: source.noInvariant ? false : source.invariant,
+                warning: source.noWarning ? false : source.warning
+            };
+        }
     }
 ];
+
+function readConfigItem<Reader extends ConfigReaderBase<string, unknown>>([reader, source]: Reader extends ConfigReaderBase<string, infer Source> ? readonly [Reader, Source] : never) {
+    return reader.read(source);
+}
 
 export default async function readConfig(opts: BuildOpts): Promise<Config> {
     const packageInfo = await readPackageInformation();
@@ -43,6 +76,7 @@ export default async function readConfig(opts: BuildOpts): Promise<Config> {
     const readers: ConfigReader[] = [
         ...staticReaders,
         {
+            type: "file",
             path: opts.config,
             read(source) {
                 return JSON.parse(source);
@@ -64,18 +98,25 @@ export default async function readConfig(opts: BuildOpts): Promise<Config> {
         recommendedExprCheck: true
     };
 
-    const configWithAbsPath = await Promise.all(readers.map(async reader => {
-        const absolutePath = await resolveUserFile(reader.path);
-        return [reader, absolutePath, existsSync(absolutePath)] as const;
-    }))
-        .then(res => res.filter(([, , exists]) => exists))
-        .then(res => res.map(([reader, path]) => [reader, path] as const));
+    const loadedConfig = (await Promise.all(
+        readers
+            .sort((a, b) => a.order ?? 0 - b.order ?? 0)
+            .map(async reader => {
+                switch (reader.type) {
+                    case "cli":
+                        return [reader, opts] as const;
+                    case "file":
+                        const resolved = await resolveUserFile(reader.path);
+                        if (!existsSync(resolved)) return null;
+                        return [reader, await readFile(resolved, "utf8")] as const;
+                }
+            })
+    )).filter(el => el);
 
     let configObj = {...defaultConfig};
 
-    for (const [config, absPath] of configWithAbsPath) {
-        const fileContents = await readFile(absPath, "utf8");
-        const fileConfig = config.read(fileContents);
+    for (const configItem of loadedConfig) {
+        const fileConfig = readConfigItem<typeof configItem[0]>(configItem);
 
         if (fileConfig.cjsOut) configObj.cjsOut = await resolveUserFile(fileConfig.cjsOut);
         if (fileConfig.esmOut) configObj.esmOut = await resolveUserFile(fileConfig.esmOut);


### PR DESCRIPTION
Allows you to use a different configuration file for a build, which means it is possible to do things like having multiple entrypoints now (although it's still not super easy).

This change also adds every configuration option to the CLI, so you don't have to create a file if it's a once-off.