### PR TITLE
AbortController is not defined in CI build

### DIFF
--- a/.changeset/smart-eggs-kiss.md
+++ b/.changeset/smart-eggs-kiss.md
@@ -1,0 +1,5 @@
+---
+"@alduino/pkg-lib": patch
+---
+
+Add ponyfill for `AbortController` in task system

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "enquirer": "^2.3.6",
     "esbuild": "^0.12.20",
     "execa": "^5.1.1",
+    "node-abort-controller": "^3.0.0",
     "resolve-bin": "^0.4.1",
     "sade": "^1.7.4",
     "tiny-invariant": "^1.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,7 @@ specifiers:
   enquirer: ^2.3.6
   esbuild: ^0.12.20
   execa: ^5.1.1
+  node-abort-controller: ^3.0.0
   resolve-bin: ^0.4.1
   sade: ^1.7.4
   tiny-invariant: ^1.1.0
@@ -45,6 +46,7 @@ dependencies:
   enquirer: 2.3.6
   esbuild: 0.12.20
   execa: 5.1.1
+  node-abort-controller: 3.0.0
   resolve-bin: 0.4.1
   sade: 1.7.4
   tiny-invariant: 1.1.0
@@ -1637,6 +1639,10 @@ packages:
 
   /ms/2.1.2:
     resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
+    dev: false
+
+  /node-abort-controller/3.0.0:
+    resolution: {integrity: sha512-IqMCPbihDpbHV4bNws015hU0svIBGyzPjJearwXMGJyungWdblbBcboNojTz9bWOrrJD3zIwmcr5w5c+NH+2+A==}
     dev: false
 
   /node-releases/1.1.74:

--- a/src/utils/tasks.ts
+++ b/src/utils/tasks.ts
@@ -1,4 +1,5 @@
 import logger from "consola";
+import {AbortController, AbortSignal} from "node-abort-controller";
 
 export interface TaskConfig<Context> {
     /**


### PR DESCRIPTION
Closes #8 

Use `node-abort-controller` as a ponyfill for `AbortController`s in Node.