### PR TITLE
Remove package name from default cjs outputs

### DIFF
--- a/.changeset/loud-kiwis-protect.md
+++ b/.changeset/loud-kiwis-protect.md
@@ -1,0 +1,5 @@
+---
+"@alduino/pkg-lib": patch
+---
+
+CJS development and production builds will no longer include the package name, to make it simpler and to prevent situations where the package name is an invalid file name

--- a/src/utils/readConfig.ts
+++ b/src/utils/readConfig.ts
@@ -86,8 +86,8 @@ export default async function readConfig(opts: BuildOpts): Promise<Config> {
 
     const defaultConfig: Partial<Config> = {
         cjsOut: "dist/index.js",
-        cjsDevOut: `dist/${packageInfo.name}.development.js`,
-        cjsProdOut: `dist/${packageInfo.name}.production.min.js`,
+        cjsDevOut: `dist/development.js`,
+        cjsProdOut: `dist/production.min.js`,
         esmOut: "dist/index.mjs",
         platform: "neutral",
         target: "es6",


### PR DESCRIPTION
To make it simpler and to prevent situations where the package name is an invalid file name