### PR TITLE
Fix various tsconfig issues

### DIFF
--- a/.changeset/bright-impalas-lay.md
+++ b/.changeset/bright-impalas-lay.md
@@ -1,0 +1,6 @@
+---
+"@alduino/pkg-lib": patch
+---
+
+Fix various tsconfig issues - Typescript features will now only run if there is a tsconfig.json file, 
+and pkg-lib will now warn you if your entrypoint is a Typescript file but there is no tsconfig.json

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -23,10 +23,7 @@ export type BuildOpts = Partial<Omit<Config, keyof BuildOptsChanges>> &
 export default async function build(opts: BuildOpts): Promise<void> {
     logger.level = opts.verbose ? LogLevel.Verbose : LogLevel.Info;
 
-    const context: TaskContext = {
-        opts,
-        ...(await getListrContext())
-    };
+    const context: TaskContext = await getListrContext(opts);
 
     await mkdir(context.cacheDir, {recursive: true});
 

--- a/src/commands/watch.ts
+++ b/src/commands/watch.ts
@@ -264,9 +264,8 @@ export default async function watch(opts: WatchOpts): Promise<void> {
     process.stdin.setRawMode(true);
 
     const context: TaskContext = {
-        opts,
         watch: true,
-        ...(await getListrContext())
+        ...await getListrContext(opts)
     };
 
     await mkdir(context.cacheDir, {recursive: true});

--- a/src/tasks/prepare.ts
+++ b/src/tasks/prepare.ts
@@ -1,6 +1,8 @@
 import readConfig from "../utils/readConfig";
 import resolveUserFile, {getUserDirectory} from "../utils/resolveUserFile";
 import {createStaticTask} from "./utils";
+import logger from "consola";
+import {existsSync} from "fs";
 
 export default createStaticTask("Prepare", async (_, then) => {
     await then("Read configuration", async ctx => {
@@ -13,5 +15,10 @@ export default createStaticTask("Prepare", async (_, then) => {
             packageJson: await resolveUserFile("package.json"),
             tsconfig: await resolveUserFile("tsconfig.json")
         };
+    });
+    await then("Run checks", async ctx => {
+        if (!existsSync(ctx.paths.tsconfig) && /\.tsx?$/.test(ctx.config.entrypoint)) {
+            logger.warn("Entrypoint is a Typescript file but there is no tsconfig.json file. Typescript-specific features will not run.");
+        }
     });
 });

--- a/src/tasks/typescript/declaration.ts
+++ b/src/tasks/typescript/declaration.ts
@@ -18,7 +18,7 @@ export const buildDeclaration = createStaticTask(
         );
 
         // require tsconfig to have `include` or `files` set
-        const tsconfig = await readTsconfig();
+        const tsconfig = await readTsconfig(true);
         invariant(
             tsconfig.include || tsconfig.files,
             "tsconfig must have `include` or `files` keys, to exclude temporary build files"

--- a/src/tasks/typescript/declaration.ts
+++ b/src/tasks/typescript/declaration.ts
@@ -35,7 +35,7 @@ export const buildDeclaration = createStaticTask(
         const expectedExcludeItems = ["**/node_modules", "**/.*/"];
 
         if (
-            !expectedExcludeItems.every(item => tsconfig.exclude.includes(item))
+            !expectedExcludeItems.every(item => tsconfig.exclude?.includes(item))
         ) {
             logger.warn(
                 `\`exclude\` in tsconfig should contain ${expectedExcludeItems

--- a/src/tasks/typescript/index.ts
+++ b/src/tasks/typescript/index.ts
@@ -7,6 +7,7 @@ import documentation, {
     CUSTOM_DOCUMENTER_EXTS
 } from "./documentation";
 import prepare from "./prepare";
+import readTsconfig from "../../utils/readTsconfig";
 
 export default createStaticTask(
     "Typescript features",
@@ -16,6 +17,7 @@ export default createStaticTask(
         await documentation(then);
     },
     {
+        enabled: async () => !!await readTsconfig(),
         async cleanup({
             paths: {userDir},
             tsDeclTempEntry,

--- a/src/utils/getListrContext.ts
+++ b/src/utils/getListrContext.ts
@@ -31,10 +31,6 @@ export default async function getListrContext(opts: BuildOpts): Promise<TaskCont
         );
     }
 
-    if (!tsconfig && /\.tsx?$/.test(opts.entrypoint)) {
-        logger.warn("Entrypoint is a Typescript file but there is no tsconfig.json file. Typescript-specific features will not run.");
-    }
-
     return {
         jsx: jsxTransform,
         cacheDir,

--- a/src/utils/getListrContext.ts
+++ b/src/utils/getListrContext.ts
@@ -22,7 +22,7 @@ export default async function getListrContext(): Promise<Pick<TaskContext, "jsx"
         ? "react-jsx"
         : "createElement";
 
-    invariant(tsconfig?.compilerOptions?.isolatedModules, "compilerOptions.isolatedModules must be `true` in your tsconfig");
+    invariant(!tsconfig || tsconfig.compilerOptions?.isolatedModules, "compilerOptions.isolatedModules must be `true` in your tsconfig");
 
     if (jsxOpt === "react-jsx") {
         logger.warn(

--- a/src/utils/getListrContext.ts
+++ b/src/utils/getListrContext.ts
@@ -4,8 +4,9 @@ import TaskContext from "../tasks/TaskContext";
 import getTemporaryFile from "./getTemporaryFile";
 import readTsconfig from "./readTsconfig";
 import {getUserDirectory} from "./resolveUserFile";
+import {BuildOpts} from "../commands/build";
 
-export default async function getListrContext(): Promise<Pick<TaskContext, "jsx" | "cacheDir">> {
+export default async function getListrContext(opts: BuildOpts): Promise<TaskContext> {
     logger.log(
         "Hint: Add `.pkglib-cache.*.tmp` to your ignore file to ignore pkg-lib's cache"
     );
@@ -30,8 +31,13 @@ export default async function getListrContext(): Promise<Pick<TaskContext, "jsx"
         );
     }
 
+    if (!tsconfig && /\.tsx?$/.test(opts.entrypoint)) {
+        logger.warn("Entrypoint is a Typescript file but there is no tsconfig.json file. Typescript-specific features will not run.");
+    }
+
     return {
         jsx: jsxTransform,
-        cacheDir
+        cacheDir,
+        opts
     };
 }


### PR DESCRIPTION
- Check if the `exlude` key in the tsconfig exists before checking if it contains the recommended values (#22)
- Only run Typescript features if the tsconfig file exists
- Warn if the entrypoint is a Typescript file but there is no tsconfig