### PR TITLE
Include all potential replacements in cursory Babel plugin check

### DIFF
--- a/.changeset/seven-deers-walk.md
+++ b/.changeset/seven-deers-walk.md
@@ -1,0 +1,5 @@
+---
+"@alduino/pkg-lib": patch
+---
+
+Include all potential replacements (`invariant`, `warning`, `__DEV__`) in the cursory check to see if a file needs to be transformed by Babel

--- a/src/utils/build-configs.ts
+++ b/src/utils/build-configs.ts
@@ -215,7 +215,12 @@ async function pkglibPlugin(
         setup(build: PluginBuild) {
             build.onLoad({filter: /\.m?[jte]s[\dm]?$/}, async args => {
                 const src = await readFile(args.path, "utf8");
-                if (!src.includes("invariant")) return {};
+                const checkedValues = [
+                    ...config.invariant,
+                    ...config.warning,
+                    "__DEV__"
+                ];
+                if (checkedValues.every(el => !src.includes(el))) return {};
                 const result = await transform(src, {
                     plugins: [
                         "@babel/plugin-transform-typescript",


### PR DESCRIPTION
Fixes #37 by checking to see if the current file includes all of the values that are replaced, not just `invariant`. Also now based on the configuration, not just a constant value (as the user can set their own `invariant` and `warning` functions)