### PR TITLE
Fix various issues with entrypoints

### DIFF
--- a/.changeset/violet-ravens-return.md
+++ b/.changeset/violet-ravens-return.md
@@ -1,0 +1,5 @@
+---
+"@alduino/pkg-lib": patch
+---
+
+Fix some issues with entrypoints

--- a/README.md
+++ b/README.md
@@ -84,8 +84,8 @@ For now, the actual code is emitted before tsc runs so you should still be able 
 
 pkg-lib reads its config from a `.pkglibrc` JSON file. Here’s the big list of every configuration option.
 
-- `entrypoint`: The package’s root, will be compiled as an entrypoint named by `mainEntryOut`. Defaults a `src/index`
-  that is a `js`, `ts`, `cjs`, `mjs`, `ejs`, or `esm` file.
+- `entrypoint`: The package’s root, will be compiled as an entrypoint named by `mainEntryOut`. Set to `false` to disable 
+  automatic detection. Defaults a `src/index` that is a `js`, `ts`, `cjs`, `mjs`, `ejs`, or `esm` file.
 - `entrypoints`: A list of named entrypoints. See [here](#custom-entrypoints) for the format of the value. Defaults to
   any files with the above extensions in `./entry` or the root project directory.
 - `typings`: Output for Typescript typings. Defaults to `[entrypoint].d.ts`.

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -1,7 +1,8 @@
 import {Platform} from "esbuild";
 
 export default interface Config {
-    entrypoint? : string;
+    hasMainEntrypoint?: boolean;
+    entrypoint?: string;
     entrypoints?: Record<string, string>;
     typings: string;
     mainEntry?: string;

--- a/src/utils/readConfig.ts
+++ b/src/utils/readConfig.ts
@@ -10,7 +10,7 @@ import detectEntrypoint, {
     resolveEntrypoints
 } from "./entrypoint";
 import fillNameTemplate from "./fillNameTemplate";
-import getEntrypointMatch from "./getEntrypointMatch";
+import getEntrypointMatch, {getEntrypointName} from "./getEntrypointMatch";
 import resolveUserFile from "./resolveUserFile";
 
 interface FileConfigChanges {
@@ -325,8 +325,16 @@ export default async function readConfig(opts: BuildOpts): Promise<Config> {
     }
 
     const hadNoEntrypoint = !configObj.entrypoint;
-    if (!configObj.entrypoint && configObj.hasMainEntrypoint !== false)
+    if (!configObj.entrypoint && configObj.hasMainEntrypoint !== false) {
         configObj.entrypoint = await detectEntrypoint();
+
+        if (!configObj.mainEntry) {
+            configObj.mainEntry = getEntrypointName(
+                configObj.entrypoint,
+                `src/index.{${entrypointExtensions}}`
+            );
+        }
+    }
 
     if (!configObj.entrypoints) {
         addEntrypoints(

--- a/src/utils/readConfig.ts
+++ b/src/utils/readConfig.ts
@@ -285,12 +285,9 @@ export default async function readConfig(opts: BuildOpts): Promise<Config> {
             configItem
         );
 
-        if (fileConfig.cjsOut)
-            configObj.cjsOut = await resolveUserFile(fileConfig.cjsOut);
-        if (fileConfig.esmOut)
-            configObj.esmOut = await resolveUserFile(fileConfig.esmOut);
-        if (fileConfig.entrypoint)
-            configObj.entrypoint = await resolveUserFile(fileConfig.entrypoint);
+        if (fileConfig.cjsOut) configObj.cjsOut = fileConfig.cjsOut;
+        if (fileConfig.esmOut) configObj.esmOut = fileConfig.esmOut;
+        if (fileConfig.entrypoint) configObj.entrypoint = fileConfig.entrypoint;
         if (fileConfig.entrypoints) {
             if (!configObj.entrypoints) configObj.entrypoints = {};
             addEntrypoints(

--- a/src/utils/readConfig.ts
+++ b/src/utils/readConfig.ts
@@ -324,16 +324,9 @@ export default async function readConfig(opts: BuildOpts): Promise<Config> {
             configObj.docsDir = await resolveUserFile(fileConfig.docsDir);
     }
 
-    const hadNoEntrypoint = !configObj.entrypoint;
     if (!configObj.entrypoint && configObj.hasMainEntrypoint !== false) {
         configObj.entrypoint = await detectEntrypoint();
-
-        if (!configObj.mainEntry) {
-            configObj.mainEntry = getEntrypointName(
-                configObj.entrypoint,
-                `src/index.{${entrypointExtensions}}`
-            );
-        }
+        if (!configObj.mainEntry) configObj.mainEntry = "index";
     }
 
     if (!configObj.entrypoints) {
@@ -358,19 +351,10 @@ export default async function readConfig(opts: BuildOpts): Promise<Config> {
         "No entrypoints are defined"
     );
 
-    if (hadNoEntrypoint) {
-        invariant(
-            !configObj.entrypoint || configObj.mainEntry,
-            "A main entrypoint was automatically detected, but was not configured to have a name. Either add " +
-                "a `main` field to your package.json, disable it by setting `entrypoint` to `false` in .pkglibrc, or" +
-                "remove the src/index file."
-        );
-    } else {
-        invariant(
-            !configObj.entrypoint || configObj.mainEntry,
-            "`mainEntry` must be defined if `entrypoint` is defined"
-        );
-    }
+    invariant(
+        !configObj.entrypoint || configObj.mainEntry,
+        "`mainEntry` must be defined if `entrypoint` is defined"
+    );
 
     invariant(
         !configObj.mainEntry || configObj.entrypoint,


### PR DESCRIPTION
- Don't resolve the output file names, so that the package.json validator doesn't freak out
- Allow the automatic entrypoint detection to be disabled by setting `entrypoint` to `false`
- Set the main entrypoint name to `index` if the entrypoint was automatically detected, and the name wasn't overridden